### PR TITLE
Updated query param snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,20 @@ devtools-snippets / formcontrols](https://github.com/bgrins/devtools-snippets/tr
 ### 1.3.4. Get Query Parameters
 [This snippet](/snippets/get-query-params.js) is a very simple yet useful snippet.
 <br>
-When you run the snippet on a page, it will print all of the query parameters in the URL in a nice & tidy table format in the console. This is helpful in viewing all of the query parameters when the URL is very long and contains non-legible texts.
+When you run the snippet on a page, it will print all of the query parameters as well as hash strings in the URL in a nice & tidy table format in the console. This is helpful in viewing all of the query parameters when the URL is very long and contains non-legible texts such as authentication URLs and complex redirection URLs.
 <br>
-**Reference**: [bgrins
+It also exposes two methods under `window` namespace i.e. `printQP` and 'printURLHash' to print query parameters and hash strings in the URL respectively. These methods also accept an optional URL string in case the desired URL is other than the current URL.
+<br>
+Usage:
+```js
+  // Will print query parameters of the current URL
+  window.printQP();
+  // Will print query parameters of the URL passed as an argument
+  window.printQP('https://example.com/page.html?token=skdjlsjdfsdsj');
+  // 'printURLHash' can be used similarly
+```
+<br>
+**Inspired from**: [bgrins
 /
 devtools-snippets / querystringvalues](https://github.com/bgrins/devtools-snippets/tree/master/snippets/querystringvalues)
 

--- a/snippets/get-query-params.js
+++ b/snippets/get-query-params.js
@@ -1,18 +1,52 @@
-// querystringvalues.js
-// https://github.com/bgrins/devtools-snippets
-// Print out key/value pairs from querystring.
+// get-query-params.js
+// https://github.com/tusharshuklaa/chrome-dev-tools-snippets-collection
+// Print out key/value pairs from querystring and hash string form URL.
 
 (function() {
 
-  const url = location;
-  const querystring = location.search.slice(1);
-  const prettify = qs => decodeURIComponent(qs.split("=")[1]).replace(/ /g,' ').replace(/\+/g, ' ');
-  const tab = querystring.split("&").map(qs => ({ "Key": qs.split("=")[0], "Value": qs.split("=")[1], "Pretty Value": prettify(qs) }));
-  const groupName = "Query Parameters";
+  const _getUrl = url => {
+    return new URL(`${(url || location)}`);
+  };
 
-  console.group(groupName);
-  console.log(`URL ${url}\nQS: ${querystring}`);
-  console.table(tab);
-  console.groupEnd(groupName);
+  const _printTable = config => {
+    const prettify = qs => decodeURIComponent(qs.split("=")[1]).replace(/ /g,' ').replace(/\+/g, ' ');
+    const tab = config.items.map(qs => (
+      { "Key": qs.split("=")[0], "Value": qs.split("=")[1], "Pretty Value": prettify(qs) }
+    ));
+
+    console.group(config.groupName);
+    console.log(`URL ${config.url}\n${config.type}: ${config.typeString}`);
+    console.table(tab);
+    console.groupEnd(config.groupName);
+  };
+
+  window.printQP = url => {
+    const _url = _getUrl(url);
+    const querystring = _url.search.slice(1);
+
+    _printTable({
+      groupName: 'Query Parameters',
+      type: 'QS',
+      items: querystring.split("&"),
+      typeString: querystring,
+      url: _url,
+    });
+  };
+
+  window.printURLHash = url => {
+    const _url = _getUrl(url);
+    const hash = _url.hash.slice(1);
+
+    _printTable({
+      groupName: 'URL Hashes',
+      type: 'Hash',
+      items: hash.split("&"),
+      typeString: hash,
+      url: _url,
+    });
+  }
+
+  window.printQp();
+  window.printURLHash();
 
 })();


### PR DESCRIPTION
- Added option to print hash string as well
- Exposed functions under window namespace for printing query params as well as hash strings in a URL
- Added an option to get query params OR hash strings of a URL other than the current URL